### PR TITLE
Added CancelGameCommand to VM

### DIFF
--- a/src/Codebreaker.ViewModels/Codebreaker.ViewModels.csproj
+++ b/src/Codebreaker.ViewModels/Codebreaker.ViewModels.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-	<PackageReference Include="CNinnovation.Codebreaker.GamesClient" Version="3.6.0-beta.21" />
+	<PackageReference Include="CNinnovation.Codebreaker.GamesClient" Version="3.6.0-beta.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Codebreaker.ViewModels/Codebreaker.ViewModels.csproj
+++ b/src/Codebreaker.ViewModels/Codebreaker.ViewModels.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-	<PackageReference Include="CNinnovation.Codebreaker.GamesClient" Version="3.6.0-beta.24" />
+    <PackageReference Include="CNinnovation.Codebreaker.GamesClient" Version="3.6.0-beta.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Codebreaker.ViewModels/Messages/GameCancelledMessage.cs
+++ b/src/Codebreaker.ViewModels/Messages/GameCancelledMessage.cs
@@ -1,0 +1,3 @@
+﻿namespace Codebreaker.ViewModels.Messages;
+
+public record class GameCancelledMessage();


### PR DESCRIPTION
# Pull Request Summary

This pull request includes several significant changes to the game functionality in the `Codebreaker` project. The main focus of these changes is to introduce the ability to cancel a game and handle the associated scenarios.

## Package Update

The `CNinnovation.Codebreaker.GamesClient` package in `Codebreaker.ViewModels.csproj` was updated from `3.6.0-beta.21` to `3.6.0-beta.24`. This update is necessary to keep the project up-to-date with the latest features and improvements of the package.

## New Class and Method

A new class `GameCancelledMessage` was added to `GameCancelledMessage.cs`. This class is used to send a message when a game is cancelled.

In `GamePageViewModel.cs`, a new method `CanCancelGame` was added. This method checks if a game can be cancelled by verifying that the game is not null and not finished. This is a crucial check to prevent any unwanted behavior or errors.

## Game Cancellation

A new `RelayCommand` attribute was added to a new method `CancelGameAsync`. This method is responsible for cancelling the game if it is not null. If the game is null, it throws an `InvalidOperationException`, ensuring that the game exists before attempting to cancel it.

The `CancelGameAsync` method also handles different scenarios that might occur during the cancellation process. If the game cannot be cancelled due to a `BadRequest` HTTP status code, it shows an info bar message "Could not cancel the game". If there are networking issues, it shows an info bar message "Networking issues". These messages provide feedback to the user about the status of the cancellation process.

After successfully cancelling the game, the method sets the game to null and sends a `GameCancelledMessage`. This design decision ensures that the game state is properly reset after cancellation and that other parts of the application are notified about the cancellation.
