### PR TITLE
Update NuGet build

### DIFF
--- a/.github/workflows/codebreaker-lib-viewmodels.yml
+++ b/.github/workflows/codebreaker-lib-viewmodels.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     uses: CodebreakerApp/Codebreaker.XAML/.github/workflows/createnuget-withbuildnumber.yml@main
     with:
-      version-suffix: beta.
+      version-suffix: preview.1.
       version-number: ${{ github.run_number }}
       version-offset: 10
       solutionfile-path: src/CodeBreaker.ViewModels.sln
@@ -38,9 +38,9 @@ jobs:
       artifact-name: codebreaker-viewmodels
     secrets: inherit
 
-  publishnuget:
-    uses: CodebreakerApp/Codebreaker.XAML/.github/workflows/publishnuget-nugetserver.yml@main
-    needs: publishdevops
-    with:
-      artifact-name: codebreaker-viewmodels
-    secrets: inherit
+  # publishnuget:
+  #  uses: CodebreakerApp/Codebreaker.XAML/.github/workflows/publishnuget-nugetserver.yml@main
+  #  needs: publishdevops
+  #  with:
+  #    artifact-name: codebreaker-viewmodels
+  #  secrets: inherit

--- a/.github/workflows/createnuget-withbuildnumber.yml
+++ b/.github/workflows/createnuget-withbuildnumber.yml
@@ -54,7 +54,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with: 
           dotnet-version: ${{ inputs.dotnet-version }}
-          dotnet-quality: 'preview'
 
       - name: Calculate version suffix with offset
         id: version
@@ -86,5 +85,5 @@ jobs:
         with:
           name: ${{ inputs.artifact-name }}
           path: packages/*
-          retention-days: 3
+          retention-days: 7
   

--- a/publishnuget.md
+++ b/publishnuget.md
@@ -1,0 +1,20 @@
+# GitHub Actions
+
+## Publish to Azure DevOps
+
+[Azure DevOps feed for daily builds](https://pkgs.dev.azure.com/cnilearn/codebreakerpackages/_packaging/codebreaker/nuget/v3/index.json)
+
+Daily build version of NuGet packages (*CNinnovation.Codebreaker.ViewModels*) are published to Azure DevOps with every merge to the main branch.
+
+For publishing, an Azure DevOps PAT is required.
+Permissions: Packaging, Read & Write
+
+The PAT is configured with the environment *DevOpsArtifacts" actions secret *DEVOPS_ARTIFACT_PAT*.
+
+Valid until 2025/01/12
+
+## Publish to NuGet
+
+Preview and release versions are published to the NuGet server.
+
+[CNInnovation.Codebreaker.ViewModels](https://www.nuget.org/packages/CNInnovation.Codebreaker.ViewModels/)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>3.7.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- change version to 4.x preview.1
- add publishnuget.md with information on changing the PAT for nuget deployment with ADO
- temporary disable publish to nuget.org (until stabilization of the preview.1 version)